### PR TITLE
Hobbysite urls

### DIFF
--- a/commissions/templates/commissions_list.html
+++ b/commissions/templates/commissions_list.html
@@ -10,7 +10,7 @@
         <ul>
             {% for commission in commissions %}
                 <li>
-                    <a href="{% url 'commission_detail' commission.id %}">
+                    <a href="{% url 'commissions:commission_detail' commission.id %}">
                         {{ commission.title }}
                     </a>
                 </li>

--- a/hobbysite/urls.py
+++ b/hobbysite/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path("forum/", include("forum.urls")),
     path("blog/", include("blog.urls")),
     path("merchstore/", include("merchstore.urls")),
+    path("commissions/", include("commissions.urls"))
 ]


### PR DESCRIPTION
Added commissions to the project urls
Also added commissions name to the list template, django cannot find the name of the commissions_detail without it.